### PR TITLE
Add GitHub Action for Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+
+  win32:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get tag
+      id: tag
+      shell: bash
+      run: |
+        echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+        architecture: 'x86'
+    - name: Install PyInstaller
+      run: |
+        python -m pip install --upgrade pip
+        pip install pyinstaller
+    - name: build with PyInstaller
+      run: |
+        pyinstaller -F -n avsrepo-32 avsrepo.py
+    - name: Upload release file
+      uses: actions/upload-artifact@v1
+      with:
+        name: avsrepo-32.exe
+        path: dist/avsrepo-32.exe
+  win64:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get tag
+      id: tag
+      shell: bash
+      run: |
+        echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+        architecture: 'x64'
+    - name: Install PyInstaller
+      run: |
+        python -m pip install --upgrade pip
+        pip install pyinstaller
+    - name: build with PyInstaller
+      run: |
+        pyinstaller -F -n avsrepo-64 avsrepo.py
+    - name: Upload release file
+      uses: actions/upload-artifact@v1
+      with:
+        name: avsrepo-64.exe
+        path: dist/avsrepo-64.exe
+
+
+  Release:
+    needs: [win32, win64]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Get tag
+        id: tag
+        run: |
+          echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+      - name: Download 32-bit Windows release file
+        uses: actions/download-artifact@master
+        with:
+          name: avsrepo-32.exe
+          path: ./
+      - name: Download 64-bit Windows release file
+        uses: actions/download-artifact@master
+        with:
+          name: avsrepo-64.exe
+          path: ./
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          release_name: ${{ steps.tag.outputs.tag }}
+          draft: false
+          prerelease: false
+      - name: Upload 32-bit Windows release file asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: avsrepo-32.exe
+          asset_name: avsrepo-32.exe
+          asset_content_type: application/x-msdownload
+      - name: Upload 64-bit Windows release file asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: avsrepo-64.exe
+          asset_name: avsrepo-64.exe
+          asset_content_type: application/x-msdownload


### PR DESCRIPTION
This will create a 32-bit and 64-bit build of AVSRepo whenever a commit is given a x.x.x version tag. Then it will create a release with the version number and auto upload the built binaries.